### PR TITLE
Added fix for config loading on Windows.

### DIFF
--- a/bin/compile.js
+++ b/bin/compile.js
@@ -99,7 +99,8 @@ async function writeIndex(targetDir, filenames) {
 async function build() {
   let userConfig = {}
   try {
-    const content = await import(`${process.cwd()}/lego.config.js`)
+    const pathPrefix = process.platform === 'win32' ? 'file://' : ''
+    const content = await import(`${pathPrefix + process.cwd()}/lego.config.js`)
     userConfig = content.default
   }
   catch {


### PR DESCRIPTION
Windows won't load modules without the path being prefixed with "file://", this checks if the platform is Windows and then prefixes it as so for https://github.com/Polight/lego/issues/20