### PR TITLE
Tiny fix to pass Lego version into build process.

### DIFF
--- a/bin/compile.js
+++ b/bin/compile.js
@@ -79,6 +79,7 @@ async function compile(sourceDir, targetDir, config) {
     const component = createComponent({
       html: fs.readFileSync(f, 'utf8'),
       name: filename,
+      version,
       ...config
     })
     fs.writeFileSync(`${targetDir}/${filename}.js`, component.content, 'utf8')
@@ -106,7 +107,7 @@ async function writeIndex(targetDir, filenames) {
 async function build() {
   let userConfig = {}
   try {
-    const pathPrefix = process.platform === 'win32' ? 'file://' : ''
+    const pathPrefix = isWindows() ? 'file://' : ''
     const content = await import(`${pathPrefix + process.cwd()}/lego.config.js`)
     userConfig = content.default
   }


### PR DESCRIPTION
So that built components show the Lego version instead of undefined. The variable was already there, it just wasn't referenced.

![image](https://user-images.githubusercontent.com/1957928/142780954-11fc3d0e-499f-46b4-81ca-880a6e22e724.png)

