### PR TITLE
add: feature setup on script tag

### DIFF
--- a/src/compiler/transpiler.js
+++ b/src/compiler/transpiler.js
@@ -4,11 +4,12 @@ import parse from './vdom-parser.js'
 function parseHtmlComponent(html) {
   const templateMatch = html.match(/<template[^>]*>([\s\S]*)<\/template>/m)
   const scriptMatch = html.match(/<script[^>]*>([\s\S]*)<\/script>/m)
+  const isSetup = html.match(/<script\s*(.*?)\s*>/s)[1].includes('setup');
   const styleMatch = html.match(/<style[^>]*>([\s\S]*)<\/style>/m)
   const template = templateMatch ? templateMatch[1].trim() : ''
   const script = scriptMatch ? scriptMatch[1].trim() : ''
   const style = styleMatch ? styleMatch[1].trim() : ''
-  return { template, script, style }
+  return { template, script, style, isSetup }
 }
 
 function generateFileContent({ dom, importPath, baseClassName, version, preScript = '', preStyle = '' }) {
@@ -18,7 +19,7 @@ import { h, Component } from '${importPath}'
 
 class ${baseClassName} extends Component {
   ${dom.template.trim() ? `get vdom() {
-    return ({ state }) => ${parse(dom.template.trim())}
+    return ({ ${dom.isSetup? '' : 'state'} }) => ${parse(dom.template.trim(), dom.isSetup)}
   }` : ''}
   ${dom.style.trim() || preStyle ? `get vstyle() {
     return ({ state }) => h('style', {}, \`
@@ -30,6 +31,7 @@ class ${baseClassName} extends Component {
 ${preScript}
 
 ${dom.script.trim() || `export default class extends ${baseClassName} {}`}
+${dom.isSetup? 'export default class extends Lego {}' : ''}
 `
 }
 

--- a/src/compiler/vdom-parser.js
+++ b/src/compiler/vdom-parser.js
@@ -38,7 +38,8 @@ function cleanChildren(children = []) {
   })
 }
 
-function extractDirectives(node) {
+let isSetupMode = false
+function extractDirectives(node, isSetup = isSetupMode) {
   const directives = []
   const sibling = node.nextElementSibling
   node.attrs = node.attrs.reduce((attrs, attr) => {
@@ -54,7 +55,7 @@ function extractDirectives(node) {
     }
     else if(name.startsWith('@')) {
       name = `on${name.slice(1)}`
-      value = `this.${value}.bind(this)`
+      value = isSetup === true ? `${value}.bind(this)` : `this.${value}.bind(this)`
       attrs.push({ name, value })
     }
     else attrs.push({ name, value: `\`${value}\`` })
@@ -124,7 +125,8 @@ function convert(node, indentSize = 0, sibling) {
 
 }
 
-function parse(html) {
+function parse(html, isSetup) {
+  isSetupMode = isSetup
   const document = parser.parseFragment(html)
   return convert(document)
 }


### PR DESCRIPTION
with the `setup` prop inside script tag now you can add script outside class like so and it is not a breaking change  :smiley:
Also i was thinking on allow `.vue` files alogside with `{{ }}` syntax and get autcomplete help from editor but I think for now it's ok

```js
<script setup>
  let count = 0
  const state = { name: "World!", count: 0, k: { a: 'a', p: 0 } }

  function has(e) {
    count++
    state.count++
    console.log(e);
    this.render()
  }

  function gas() {
    state.k.p++
    this.render()
  }

</script>
```
```html
<template>
  <div>
    <p @click="has">Hello ${ state.name } ${ state.count } ${ count }</p>
    <p @click="gas">
      ${ state.k.a } ${ state.k.p }
    </p>
  </div>
</template>
```