### PR TITLE
CDN import should fit the current version

### DIFF
--- a/src/compiler/config.js
+++ b/src/compiler/config.js
@@ -1,8 +1,10 @@
+import {version} from '../../package.json';
+
 export default {
   // Path to the Lego Component class.
   // When relative, it should be referenced from within the dist folder
   // where the compiled bricks reside
-  importPath: 'https://cdn.jsdelivr.net/gh/Polight/lego@master/dist/lego.min.js',
+  importPath: `https://cdn.jsdelivr.net/npm/@polight/lego@${version}/dist/lego.min.js`,
 
   // When building a Component, set the default name of the class to extend.
   // This is the name that you will use to extend your components with


### PR DESCRIPTION
The `lego` import in the default config uses JSDelivr CDN. This import should be based on the current installed version of `lego` to simplify debugging.