### PR TITLE
Correctly handle attributes based on their type

### DIFF
--- a/src/lib/Component.js
+++ b/src/lib/Component.js
@@ -5,11 +5,18 @@ function toCamelCase(name) {
   return name.replace(/-([a-z])/g, (match, letter) => letter.toUpperCase())
 }
 
-function sanitizeJsonAttribute(attr) {
+function sanitizeAttribute(attrType, attrValue) {
+  if (attrType === 'object') return sanitizeJsonAttribute(attrValue)
+  if (attrType === 'boolean') return attrValue === "" || !!attrValue
+  if (attrType === 'number') return parseInt(attrValue)
+  return attrValue
+}
+
+function sanitizeJsonAttribute(attrValue) {
   try {
-    return JSON.parse(attr)
+    return JSON.parse(attrValue)
   } catch (_) {
-    return attr
+    return attrValue
   }
 }
 
@@ -34,22 +41,16 @@ class Component extends HTMLElement {
     this.state = Array.from(this.attributes).reduce(
       (state, attr) => {
         const camelCaseName = toCamelCase(attr.name)
+        const attrType = typeof this.state[camelCaseName]
         return {
           ...state,
-          [camelCaseName]: this.#sanitizeAttribute(camelCaseName, attr.value),
+          [camelCaseName]: sanitizeAttribute(attrType, attr.value),
         }
       },
       this.state
     )
   }
 
-  #sanitizeAttribute(attrName, attrValue) {
-    const attrType = typeof this.state[attrName]
-    if (attrType === 'object') return sanitizeJsonAttribute(attrValue)
-    if (attrType === 'boolean') return attrValue === "" || !!attrValue
-    if (attrType === 'number') return parseInt(attrValue)
-    return attrValue
-  }
 
   get vdom() {
     return ({ state }) => ""
@@ -62,14 +63,16 @@ class Component extends HTMLElement {
   setAttribute(name, value) {
     super.setAttribute(name, typeof value === 'object' ? JSON.stringify(value) : value)
     const prop = toCamelCase(name)
-    if (this.#watchProps.includes(prop)) this.render({ [prop]: this.#sanitizeAttribute(prop, value) })
+    const attrType = typeof this.state[prop]
+    if (this.#watchProps.includes(prop)) this.render({ [prop]: sanitizeAttribute(attrType, value) })
   }
 
   removeAttribute(name) {
     super.removeAttribute(name)
     const prop = toCamelCase(name)
+    const attrType = typeof this.state[prop]
     if (this.#watchProps.includes(prop) && prop in this.state) {
-      this.render({ [prop]: this.#sanitizeAttribute(prop, null) })
+      this.render({ [prop]: sanitizeAttribute(attrType, null) })
     }
   }
 

--- a/src/lib/Component.js
+++ b/src/lib/Component.js
@@ -8,7 +8,7 @@ function toCamelCase(name) {
 function sanitizeAttribute(attrType, attrValue) {
   if (attrType === 'object') return sanitizeJsonAttribute(attrValue)
   if (attrType === 'boolean') return attrValue === "" || !!attrValue
-  if (attrType === 'number') return parseInt(attrValue)
+  if (attrType === 'number') return Number(attrValue)
   return attrValue
 }
 


### PR DESCRIPTION
Keeping on going on #56, I have noticed that boolean attributes are not correctly handled. As `petit-dom` transforms it into `attribute=""` when true or removes it when false, it leads to the state `attribute: ""` in the brick which is considered as false. Also, once removed because set to false, the attribute is not re-added when set to true.

Somehow, I had this time issues with integers that need to be parsed (as `"0"` is considered as true).

Is in conflict with #56 and needs it to be merged first.