### PR TITLE
Remove useless callbacks

### DIFF
--- a/src/lib/Component.js
+++ b/src/lib/Component.js
@@ -81,12 +81,10 @@ class Component extends HTMLElement {
     this.#isConnected = true
     // Load the DOM
     this.render()
-    this.connected?.()
   }
 
   disconnectedCallback() {
     this.#isConnected = false
-    this.disconnected?.()
   }
 
   setState(props = {}) {


### PR DESCRIPTION
IMHO, `connected` and `disconnected` callbacks are useless compared to overriding native Web components lifecycle callbacks. Indeed, this way, the user has the choice to do some actions before OR/AND after calling the Lego hook:

```js
connectedCallback() {
  // ... some actions before connecting the component
  super.connectedCallback()
  // ... some actions after connecting the component
} // same for disconnectedCallback
```

Moreover, it gives more clues to the user how Lego works and deals with native Web components, and somehow would have a pedagogy purpose by introducing the user to native Web components (maybe am I dreaming? 😅). 